### PR TITLE
fixed tokenGenerator so login works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.pnp.js
 
 # testing
-/coverage
+backend/coverage
 
 # production
 */build

--- a/backend/models/token_generator.js
+++ b/backend/models/token_generator.js
@@ -1,17 +1,17 @@
 import JWT from "jsonwebtoken";
 
-const secret = process.env.JWT_SECRET;
-
 export class TokenGenerator {
   static jsonwebtoken(user_id) {
-    return JWT.sign({
-      user_id: user_id,
-      iat: Math.floor(Date.now() / 1000),
-      
-      // Set the JWT token to expire in 10 minutes
-      exp: Math.floor(Date.now() / 1000) + (10 * 60)
-    }, secret);
+    const secret = process.env.JWT_SECRET;
+    return JWT.sign(
+      {
+        user_id: user_id,
+        iat: Math.floor(Date.now() / 1000),
+
+        // Set the JWT token to expire in 10 minutes
+        exp: Math.floor(Date.now() / 1000) + 10 * 60,
+      },
+      secret
+    );
   }
 }
-
-


### PR DESCRIPTION
The secret was being declared outside the class scope so it wasn't accessible. This meant login was sad. Also adds backend coverage report to gitignore so you don't get a truck load of local changes every time you run the tests.